### PR TITLE
update driver for compatibility with P8 ccpp-physics updates

### DIFF
--- a/driver/ufsLandNamelistRead.f90
+++ b/driver/ufsLandNamelistRead.f90
@@ -60,6 +60,7 @@ type, public :: namelist_type
   integer        ::  precip_partition_option
   integer        ::  soil_temp_lower_bdy_option
   integer        ::  soil_temp_time_scheme_option
+  integer        ::  thermal_roughness_scheme_option
   integer        ::  surface_evap_resistance_option
   integer        ::  glacier_option
   
@@ -139,6 +140,7 @@ contains
     integer        ::  precip_partition_option           = -999
     integer        ::  soil_temp_lower_bdy_option        = -999
     integer        ::  soil_temp_time_scheme_option      = -999
+    integer        ::  thermal_roughness_scheme_option   = -999
     integer        ::  surface_evap_resistance_option    = -999
     integer        ::  glacier_option                    = -999
 
@@ -171,6 +173,7 @@ contains
                frozen_soil_adjust_option         , radiative_transfer_option         , &
                snow_albedo_option                , precip_partition_option           , &
                soil_temp_lower_bdy_option        , soil_temp_time_scheme_option      , &
+               thermal_roughness_scheme_option   , &
                surface_evap_resistance_option    , glacier_option                    
     namelist / forcing / forcing_timestep_seconds       ,                             &
                          forcing_type                   , forcing_filename          , &
@@ -296,6 +299,7 @@ contains
       this%precip_partition_option           = precip_partition_option
       this%soil_temp_lower_bdy_option        = soil_temp_lower_bdy_option
       this%soil_temp_time_scheme_option      = soil_temp_time_scheme_option
+      this%thermal_roughness_scheme_option   = thermal_roughness_scheme_option
       this%surface_evap_resistance_option    = surface_evap_resistance_option
       this%glacier_option                    = glacier_option
     end if

--- a/driver/ufsLandNoahMPDriverModule.f90
+++ b/driver/ufsLandNoahMPDriverModule.f90
@@ -137,6 +137,7 @@ associate (                                                 &
    iopt_snf   => noahmp%options%precip_partition           ,&
    iopt_tbot  => noahmp%options%soil_temp_lower_bdy        ,&
    iopt_stc   => noahmp%options%soil_temp_time_scheme      ,&
+   iopt_trs   => noahmp%options%thermal_roughness_scheme   ,&
    iopt_rsf   => noahmp%options%surface_evap_resistance    ,&
    iopt_gla   => noahmp%options%glacier                    ,&
    soiltyp    => noahmp%static%soil_category               ,&
@@ -309,12 +310,12 @@ time_loop : do timestep = 1, namelist%run_timesteps
             shdmin, shdmax, snoalb, sfalb, flag_iter,con_g,            &
             idveg, iopt_crs, iopt_btr, iopt_run, iopt_sfc, iopt_frz,   &
             iopt_inf, iopt_rad, iopt_alb, iopt_snf, iopt_tbot,         &
-            iopt_stc, xlatin, xcoszin, iyrlen, julian, garea,          &
+            iopt_stc, iopt_trs,xlatin, xcoszin, iyrlen, julian, garea, &
             rainn_mp, rainc_mp, snow_mp, graupel_mp, ice_mp,           &
             con_hvap, con_cp, con_jcal, rhoh2o, con_eps, con_epsm1,    &
             con_fvirt, con_rd, con_hfus, thsfc_loc,                    &
             weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
-            canopy, trans, zorl,                                       &
+            canopy, trans, tsurf, zorl,                                &
             rb1, fm1, fh1, ustar1, stress1, fm101, fh21,               &
             snowxy, tvxy, tgxy, canicexy, canliqxy, eahxy, tahxy, cmxy,&
             chxy, fwetxy, sneqvoxy, alboldxy, qsnowxy, wslakexy, zwtxy,&

--- a/driver/ufsLandNoahMPType.f90
+++ b/driver/ufsLandNoahMPType.f90
@@ -40,6 +40,7 @@ type :: noahmp_options_type
   integer :: precip_partition           ! option for partitioning  precipitation into rainfall & snowfall
   integer :: soil_temp_lower_bdy        ! option for lower boundary condition of soil temperature
   integer :: soil_temp_time_scheme      ! option for snow/soil temperature time scheme (only layer 1)
+  integer :: thermal_roughness_scheme   ! option for thermal roughness length
   integer :: surface_evap_resistance    ! option for surface resistent to evaporation/sublimation
   integer :: glacier                    ! option for glacier treatment
 
@@ -582,6 +583,7 @@ contains
   this%options%precip_partition           = namelist%precip_partition_option
   this%options%soil_temp_lower_bdy        = namelist%soil_temp_lower_bdy_option
   this%options%soil_temp_time_scheme      = namelist%soil_temp_time_scheme_option
+  this%options%thermal_roughness_scheme   = namelist%thermal_roughness_scheme_option
   this%options%surface_evap_resistance    = namelist%surface_evap_resistance_option
   this%options%glacier                    = namelist%glacier_option
   


### PR DESCRIPTION
Update driver for P8 compatibility

Important notes:

- namelist now has thermal_roughness_scheme_option (set to 2 for GFS compatibility)
- surface_exchange_option should be set to 3 for GFS compatibility