### PR TITLE
Change NetCDF create to use netcdf4

### DIFF
--- a/driver/ufsLandIOModule.f90
+++ b/driver/ufsLandIOModule.f90
@@ -56,7 +56,7 @@ contains
 
     write(*,*) "Creating: "//trim(this%filename)
 
-    status = nf90_create(this%filename, NF90_CLOBBER, ncid)
+    status = nf90_create(this%filename, NF90_NETCDF4, ncid)
       if (status /= nf90_noerr) call handle_err(status)
 
 ! Define dimensions in the file.
@@ -543,7 +543,7 @@ contains
 
     write(*,*) "Creating: "//trim(this%filename)
 
-    status = nf90_create(this%filename, NF90_CLOBBER, ncid)
+    status = nf90_create(this%filename, NF90_NETCDF4, ncid)
       if (status /= nf90_noerr) call handle_err(status)
 
 ! Define dimensions in the file.

--- a/driver/ufsLandNoahMPRestartModule.f90
+++ b/driver/ufsLandNoahMPRestartModule.f90
@@ -50,7 +50,7 @@ contains
 
   write(*,*) "Creating: "//trim(this%filename)
 
-  status = nf90_create(this%filename, NF90_CLOBBER, ncid)
+  status = nf90_create(this%filename, NF90_NETCDF4, ncid)
     if (status /= nf90_noerr) call handle_err(status)
 
 ! Define dimensions in the file.

--- a/driver/ufsLandNoahRestartModule.f90
+++ b/driver/ufsLandNoahRestartModule.f90
@@ -53,7 +53,7 @@ contains
 
     write(*,*) "Creating: "//trim(this%filename)
 
-    status = nf90_create(this%filename, NF90_CLOBBER, ncid)
+    status = nf90_create(this%filename, NF90_NETCDF4, ncid)
       if (status /= nf90_noerr) call handle_err(status)
 
 ! Define dimensions in the file.


### PR DESCRIPTION
This is primarily for MPI support. Does not change answers but prohibits the use of nccmp to compare files. Use ncdiff to prove results are the same.