### PR TITLE
initialize some coupling variables

### DIFF
--- a/driver/ufsLandNoahMPDriverModule.f90
+++ b/driver/ufsLandNoahMPDriverModule.f90
@@ -263,6 +263,13 @@ allocate(     fm101(im))
 allocate(      fh21(im))
 allocate(     zvfun(im))
 
+! initialize some coupling related variables
+pblh   = 1000.0  ! arbitrary at 1000m
+rmol1  = 1.0
+flhc1  = 0.0
+flqc1  = 0.0
+ustar1 = 0.1
+
 dry        = .true.
   where(static%vegetation_category == static%iswater) dry = .false.
 flag_iter  = .true.


### PR DESCRIPTION
When adding sfcdif3 and sfcdif4 options, five new variables were added and are not initialized in the driver. This was not crashing the model even when the variables are by default initialized with huge(). Putting in more reasonable initial values does change answers. This was exposed when trying to change the huge() initialization to real*4 to prevent overflow with netcdf. Changing this arbitrary huge() initialization should not have changed answers.