### PR TITLE
initialize real data to real*4 to prevent overflow with netcdf write

### DIFF
--- a/driver/ufsLandNoahMPType.f90
+++ b/driver/ufsLandNoahMPType.f90
@@ -1357,7 +1357,7 @@ contains
     character(len=128) :: restart_names(200)
     
     allocate(indata%data (vector_length))
-    indata%data       = huge(1.0)
+    indata%data       = huge(real(1.0,4))
     indata%name       = in_name
     indata%long_name  = in_longname
     indata%units      = in_units
@@ -1386,7 +1386,7 @@ contains
     character(len=128) :: restart_names(200)
     
     allocate(indata%data (vector_length, ztop:zbot))
-    indata%data       = huge(1.0)
+    indata%data       = huge(real(1.0,4))
     indata%name       = in_name
     indata%long_name  = in_longname
     indata%units      = in_units


### PR DESCRIPTION
When reorganizing the IO code, there was problem with writing a few variables (albedo_direct and albedo_diffuse) due to overflow. This is because the output files are single precision but the data fields are initialized with huge(1.0) which is double precision (due to compiler flags to set default real to be double). Simply initialize with huge(real(1.0,4)) to get the largest single precision value. After #32 this does not change answers.