### PR TITLE
Fix time overflow and add reference_date to namelist

### DIFF
--- a/driver/ufsLandForcingModule.f90
+++ b/driver/ufsLandForcingModule.f90
@@ -264,8 +264,8 @@ contains
   integer :: iloc, latloc, lonloc, vector_shift
   double precision  :: file_next_time
   
-  call date_from_since("1970-01-01 00:00:00", now_time, now_date)
-  call date_from_since("1970-01-01 00:00:00", next_time, next_date)
+  call date_from_since(namelist%reference_date, now_time, now_date)
+  call date_from_since(namelist%reference_date, next_time, next_date)
   
   write(*,*) "Searching for forcing at time: ",now_date
   
@@ -531,7 +531,8 @@ contains
     if(namelist%forcing_time_solar == "instantaneous") then
       this%downward_shortwave = next_downward_shortwave
     elseif(namelist%forcing_time_solar == "period_average") then
-      call interpolate_zenith(now_time, next_time, namelist%subset_length,             &
+      call interpolate_zenith(namelist%reference_date,now_time, next_time,      &
+                              namelist%subset_length,                           &
                               static%latitude, static%longitude,                &
 			      namelist%timestep_seconds,                        &
                               next_downward_shortwave,                          &
@@ -582,7 +583,8 @@ contains
 
     elseif(trim(namelist%forcing_interp_solar) == "zenith") then
 
-      call interpolate_zenith(now_time, last_time, namelist%subset_length,      &
+      call interpolate_zenith(namelist%reference_date,now_time, last_time,      &
+                              namelist%subset_length,                           &
                               static%latitude, static%longitude,                &
 			      namelist%timestep_seconds,                        &
                               last_downward_shortwave,                          &

--- a/driver/ufsLandIOModule.f90
+++ b/driver/ufsLandIOModule.f90
@@ -33,7 +33,6 @@ contains
   type (forcing_type)  :: forcing
   double precision     :: now_time
   character*19     :: nowdate    ! current date
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_date
@@ -41,7 +40,7 @@ contains
   if(now_time == namelist%initial_time + namelist%timestep_seconds .or. &
      namelist%separate_output) then
   
-    call date_from_since(reference_date, now_time, nowdate)
+    call date_from_since(namelist%reference_date, now_time, nowdate)
     read(nowdate( 1: 4),'(i4.4)') yyyy
     read(nowdate( 6: 7),'(i2.2)') mm
     read(nowdate( 9:10),'(i2.2)') dd
@@ -72,7 +71,7 @@ contains
 
     status = nf90_def_var(ncid, "time", NF90_DOUBLE, dim_id_time, varid)
       status = nf90_put_att(ncid, varid, "long_name", "time")
-      status = nf90_put_att(ncid, varid, "units", "seconds since "//reference_date)
+      status = nf90_put_att(ncid, varid, "units", "seconds since "//namelist%reference_date)
 
     status = nf90_def_var(ncid, "delt", NF90_FLOAT, (/dim_id_time/), varid)
       status = nf90_put_att(ncid, varid, "long_name", "time step")
@@ -521,7 +520,6 @@ contains
   type (forcing_type)  :: forcing
   double precision     :: now_time
   character*19     :: nowdate    ! current date
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_date, dim_id_rad
@@ -531,7 +529,7 @@ contains
   if(now_time == namelist%initial_time + namelist%timestep_seconds .or. &
      namelist%separate_output ) then
   
-    call date_from_since(reference_date, now_time, nowdate)
+    call date_from_since(namelist%reference_date, now_time, nowdate)
     read(nowdate( 1: 4),'(i4.4)') yyyy
     read(nowdate( 6: 7),'(i2.2)') mm
     read(nowdate( 9:10),'(i2.2)') dd
@@ -568,7 +566,7 @@ contains
 
     status = nf90_def_var(ncid, "time", NF90_DOUBLE, dim_id_time, varid)
       status = nf90_put_att(ncid, varid, "long_name", "time")
-      status = nf90_put_att(ncid, varid, "units", "seconds since "//reference_date)
+      status = nf90_put_att(ncid, varid, "units", "seconds since "//namelist%reference_date)
 
     status = nf90_def_var(ncid, "timestep", NF90_FLOAT, (/dim_id_time/), varid)
       status = nf90_put_att(ncid, varid, "long_name", "time step")

--- a/driver/ufsLandNamelistRead.f90
+++ b/driver/ufsLandNamelistRead.f90
@@ -26,6 +26,7 @@ type, public :: namelist_type
   
   character*19   :: simulation_start
   character*19   :: simulation_end
+  character*19   :: reference_date
   integer        :: run_timesteps
   integer        :: restart_timesteps
   integer        :: output_timesteps
@@ -120,6 +121,7 @@ contains
   
     character*19   :: simulation_start = ""
     character*19   :: simulation_end = ""
+    character*19   :: reference_date = "1970-01-01 00:00:00"
 
     integer        :: run_days = -999
     integer        :: run_hours = -999
@@ -185,7 +187,7 @@ contains
                             simulation_start, simulation_end, run_days, run_hours, run_minutes, &
 			    run_seconds, run_timesteps, separate_output, location_start, location_end, &
 			    restart_dir, restart_frequency_s, restart_simulation, restart_date, &
-                            output_frequency_s, output_initial
+                            output_frequency_s, output_initial, reference_date
     namelist / land_model_option / land_model
     namelist / structure  / num_soil_levels, forcing_height
     namelist / soil_setup / soil_level_thickness, soil_level_nodes
@@ -268,6 +270,7 @@ contains
     this%subset_length        = this%location_length
     this%simulation_start     = simulation_start
     this%simulation_end       = simulation_end
+    this%reference_date       = reference_date
     this%run_days             = run_days
     this%run_hours            = run_hours
     this%run_minutes          = run_minutes
@@ -294,7 +297,7 @@ contains
     
     this%output_names  = output_names
     this%restart_names = restart_names
-    
+
     if(this%location_start <= 0 .or. this%location_end <= 0) then
       write(*,*) "location_start = ", location_start
       write(*,*) "location_end = ", location_end
@@ -342,8 +345,8 @@ contains
     end if
     
     if(restart_simulation) then
-      call calc_sec_since("1970-01-01 00:00:00",restart_date,0,run_time)
-      call date_from_since("1970-01-01 00:00:00", run_time+timestep_seconds, simulation_start)
+      call calc_sec_since(reference_date,restart_date,0,run_time)
+      call date_from_since(reference_date, run_time+timestep_seconds, simulation_start)
       this%simulation_start = simulation_start
     end if
     

--- a/driver/ufsLandNoahDriverModule.f90
+++ b/driver/ufsLandNoahDriverModule.f90
@@ -209,8 +209,8 @@ time_loop : do timestep = 1, namelist%run_timesteps
 
   call forcing%ReadForcing(namelist, static, now_time)
 
-  call interpolate_monthly(now_time, im, static%gvf_monthly, sigmaf)
-  call interpolate_monthly(now_time, im, static%albedo_monthly, sfalb)
+  call interpolate_monthly(namelist%reference_date, now_time, im, static%gvf_monthly, sigmaf)
+  call interpolate_monthly(namelist%reference_date, now_time, im, static%albedo_monthly, sfalb)
   
   albdvis_lnd = sfalb
   albdnir_lnd = sfalb

--- a/driver/ufsLandNoahMPDriverModule.f90
+++ b/driver/ufsLandNoahMPDriverModule.f90
@@ -278,7 +278,7 @@ time_loop : do timestep = 1, namelist%run_timesteps
 
   now_time = namelist%initial_time + timestep * namelist%timestep_seconds
 
-  call date_from_since("1970-01-01 00:00:00", now_time, now_date)
+  call date_from_since(namelist%reference_date, now_time, now_date)
   read(now_date(1:4),'(i4)') now_yyyy
   iyrlen = 365
   if(mod(now_yyyy,4) == 0) iyrlen = 366
@@ -299,10 +299,10 @@ time_loop : do timestep = 1, namelist%run_timesteps
    noahmp%forcing%wind_speed_forcing%data         = forcing%wind_speed
    noahmp%forcing%precipitation_forcing%data      = forcing%precipitation
   
-  call interpolate_monthly(now_time, im, static%gvf_monthly, sigmaf)
-  call interpolate_monthly(now_time, im, static%albedo_monthly, sfalb)
+  call interpolate_monthly(namelist%reference_date, now_time, im, static%gvf_monthly, sigmaf)
+  call interpolate_monthly(namelist%reference_date, now_time, im, static%albedo_monthly, sfalb)
   
-  call calc_cosine_zenith(now_time, im, static%latitude, static%longitude, xcoszin, julian)
+  call calc_cosine_zenith(namelist%reference_date, now_time, im, static%latitude, static%longitude, xcoszin, julian)
   
   u1       = wind
   v1       = 0.0_kind_phys

--- a/driver/ufsLandNoahMPRestartModule.f90
+++ b/driver/ufsLandNoahMPRestartModule.f90
@@ -32,14 +32,13 @@ contains
   type(noahmp_type)    :: noahmp
   double precision     :: now_time
   character*19     :: nowdate    ! current date
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_date, dim_id_rad
 
   integer, parameter :: output = 1, restart = 2
 
-  call date_from_since(reference_date, now_time, nowdate)
+  call date_from_since(namelist%reference_date, now_time, nowdate)
   read(nowdate( 1: 4),'(i4.4)') yyyy
   read(nowdate( 6: 7),'(i2.2)') mm
   read(nowdate( 9:10),'(i2.2)') dd
@@ -76,7 +75,7 @@ contains
 
   status = nf90_def_var(ncid, "time", NF90_DOUBLE, dim_id_time, varid)
     status = nf90_put_att(ncid, varid, "long_name", "time")
-    status = nf90_put_att(ncid, varid, "units", "seconds since "//reference_date)
+    status = nf90_put_att(ncid, varid, "units", "seconds since "//namelist%reference_date)
 
   status = nf90_def_var(ncid, "timestep", NF90_DOUBLE, dim_id_time, varid)
     status = nf90_put_att(ncid, varid, "long_name", "time step")
@@ -117,12 +116,11 @@ contains
   type (noahmp_type)   :: noahmp
   double precision     :: now_time
   
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_snow, dim_id_snso, dim_id_date
   
-  call calc_sec_since(reference_date,namelist%restart_date,0,now_time)
+  call calc_sec_since(namelist%reference_date,namelist%restart_date,0,now_time)
 
   namelist%initial_time = now_time
 

--- a/driver/ufsLandNoahMPType.f90
+++ b/driver/ufsLandNoahMPType.f90
@@ -1585,7 +1585,7 @@ contains
   real                 :: masslai, masssai, snow_depth_meters
   integer              :: ilevel, iloc, isnow
 
-  call date_from_since("1970-01-01 00:00:00", now_time, current_date)
+  call date_from_since(namelist%reference_date, now_time, current_date)
   read(current_date( 6: 7),  '(i2)') current_mm
   
   do iloc = 1, this%static%vector_length

--- a/driver/ufsLandNoahRestartModule.f90
+++ b/driver/ufsLandNoahRestartModule.f90
@@ -30,7 +30,6 @@ contains
   type(noah_type)      :: noah
   double precision     :: now_time
   character*19     :: nowdate    ! current date
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_date
@@ -38,7 +37,7 @@ contains
   if(now_time == namelist%initial_time + namelist%timestep_seconds .or. &
      namelist%separate_output) then
   
-    call date_from_since(reference_date, now_time, nowdate)
+    call date_from_since(namelist%reference_date, now_time, nowdate)
     read(nowdate( 1: 4),'(i4.4)') yyyy
     read(nowdate( 6: 7),'(i2.2)') mm
     read(nowdate( 9:10),'(i2.2)') dd
@@ -69,7 +68,7 @@ contains
 
     status = nf90_def_var(ncid, "time", NF90_DOUBLE, dim_id_time, varid)
       status = nf90_put_att(ncid, varid, "long_name", "time")
-      status = nf90_put_att(ncid, varid, "units", "seconds since "//reference_date)
+      status = nf90_put_att(ncid, varid, "units", "seconds since "//namelist%reference_date)
 
     status = nf90_def_var(ncid, "delt", NF90_DOUBLE, (/dim_id_time/), varid)
       status = nf90_put_att(ncid, varid, "long_name", "time step")
@@ -451,12 +450,11 @@ contains
   type (noah_type)     :: noah
   double precision     :: now_time
   
-  character*19     :: reference_date = "1970-01-01 00:00:00"
   integer          :: yyyy,mm,dd,hh,nn,ss
   integer :: ncid, dimid, varid, status
   integer :: dim_id_time, dim_id_loc, dim_id_soil, dim_id_date
   
-  call calc_sec_since(reference_date,namelist%restart_date,0,now_time)
+  call calc_sec_since(namelist%reference_date,namelist%restart_date,0,now_time)
 
   namelist%initial_time = now_time
 

--- a/util/module_cosine_zenith.f90
+++ b/util/module_cosine_zenith.f90
@@ -2,7 +2,7 @@ module cosine_zenith
 
 contains
 
-subroutine calc_cosine_zenith(now_time, im, latitude, longitude, cosz, julian)
+subroutine calc_cosine_zenith(reference_date, now_time, im, latitude, longitude, cosz, julian)
 
 use time_utilities
 
@@ -16,11 +16,12 @@ real                :: julian
 real                :: obecl, sinob, sxlong, arg, tloctim, hrang, declin
 integer             :: ihour, iminute, isecond, iloc
 character*19        :: now_date  ! format: yyyy-mm-dd hh:nn:ss
+character*19        :: reference_date
 
 real, parameter :: degrad = 3.14159265/180.
 real, parameter :: dpd    = 360./365.
 
-call date_from_since("1970-01-01 00:00:00", now_time, now_date)
+call date_from_since(reference_date, now_time, now_date)
 
 call calc_sec_since(now_date(1:4)//"-01-01 00:00:00", now_date, 0, sec_since)
 

--- a/util/module_interpolation_utilities.f90
+++ b/util/module_interpolation_utilities.f90
@@ -2,7 +2,7 @@ module interpolation_utilities
 
 contains
 
-subroutine interpolate_monthly(now_time, vector_length, monthly_var, interp_var)
+subroutine interpolate_monthly(reference_date, now_time, vector_length, monthly_var, interp_var)
 
 use time_utilities
 
@@ -14,6 +14,7 @@ real, dimension(vector_length,12) :: monthly_var
 real, dimension(vector_length)    :: interp_var
 
 character*19        :: before_date, after_date, current_date  ! format: yyyy-mm-dd hh:nn:ss
+character*19        :: reference_date
 double precision    :: before_time, after_time
 real                :: before_weight, after_weight
 integer             :: before_mm, after_mm, iloop
@@ -21,7 +22,7 @@ integer             :: current_yyyy, current_mm, current_dd
 
 ! get the current date string assuming reference_date
 
-call date_from_since("1970-01-01 00:00:00", now_time, current_date)
+call date_from_since(reference_date, now_time, current_date)
 
 ! assume the monthly data are valid on the 15th
 
@@ -50,8 +51,8 @@ end if
 
 ! get the time the month before and after assuming reference date
 
-call calc_sec_since("1970-01-01 00:00:00",before_date,0,before_time)
-call calc_sec_since("1970-01-01 00:00:00", after_date,0, after_time)
+call calc_sec_since(reference_date,before_date,0,before_time)
+call calc_sec_since(reference_date, after_date,0, after_time)
 
 if(before_time > now_time .or. after_time < now_time) &
    stop "problem with time in interpolate_monthly"
@@ -92,7 +93,7 @@ if(last_time > now_time .or. next_time < now_time) &
 
 end subroutine interpolate_linear
 
-subroutine interpolate_zenith(now_time, last_time, vector_length, &
+subroutine interpolate_zenith(reference_date, now_time, last_time, vector_length, &
                               latitude, longitude, timestep,      &
                               last_var, interp_var)
 
@@ -105,6 +106,7 @@ use cosine_zenith
 
 implicit none
 
+character*19                      :: reference_date
 double precision                  :: now_time, last_time
 integer                           :: vector_length, timestep
 real, dimension(vector_length)    :: latitude, longitude, last_var, interp_var
@@ -122,13 +124,13 @@ real, parameter                   :: critical_cosz   = 0.0001
 ! calculate zenith angle between the model timesteps for this forcing average
 
   calc_time = last_time + 0.5*timestep
-  call calc_cosine_zenith(calc_time, vector_length, latitude, longitude, cosz1, julian)
+  call calc_cosine_zenith(reference_date, calc_time, vector_length, latitude, longitude, cosz1, julian)
 
   calc_time = last_time + 0.5*timestep + timestep
-  call calc_cosine_zenith(calc_time, vector_length, latitude, longitude, cosz2, julian)
+  call calc_cosine_zenith(reference_date, calc_time, vector_length, latitude, longitude, cosz2, julian)
 
   calc_time = last_time + 0.5*timestep + 2*timestep
-  call calc_cosine_zenith(calc_time, vector_length, latitude, longitude, cosz3, julian)
+  call calc_cosine_zenith(reference_date, calc_time, vector_length, latitude, longitude, cosz3, julian)
 
   where(cosz1 <= critical_cosz) cosz1 = 0.0
   where(cosz2 <= critical_cosz) cosz2 = 0.0

--- a/util/module_time_utilities.f90
+++ b/util/module_time_utilities.f90
@@ -10,18 +10,24 @@ subroutine date_from_since(since_date, sec_since, current_date)
 implicit none
 character*19 :: since_date, current_date  ! format: yyyy-mm-dd hh:nn:ss
 double precision      :: sec_since
-integer      :: count_sec, count_sav
+integer*8    :: count_sec, count_sav, limit
 integer      :: since_yyyy, since_mm, since_dd, since_hh, since_nn, since_ss
 integer      :: current_yyyy, current_mm, current_dd, current_hh, current_nn, current_ss
 logical      :: leap_year = .false.
 integer      :: num_leap = 0
-integer      :: iyyyy, imm, limit
+integer      :: iyyyy, imm
 integer, dimension(12), parameter :: days_in_mm = (/31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 /)
 
   current_date = "xxxx-xx-xx xx:xx:xx"
 
-  limit = huge(1)
-  if(sec_since > limit .or. sec_since < 0) stop "not capable of dealing with sec_since"
+  limit = huge(count_sec)
+
+  if(sec_since > limit .or. sec_since < 0) then
+    print*, "sec_since: ", sec_since
+    print*, "sec_since not allowed to be negative or > integer*8"
+    print*, "choose a different reference date in namelist"
+    stop
+  end if 
 
   read(since_date( 1: 4),  '(i4)') since_yyyy
   read(since_date( 6: 7),  '(i2)') since_mm
@@ -66,7 +72,7 @@ integer, dimension(12), parameter :: days_in_mm = (/31, 28, 31, 30, 31, 30, 31, 
   
 ! find the month
 
-  current_mm = 0!since_mm
+  current_mm = 0 ! since_mm
 
   leap_year = .false.
   if(mod(current_yyyy,4) == 0) leap_year = .true.
@@ -85,7 +91,7 @@ integer, dimension(12), parameter :: days_in_mm = (/31, 28, 31, 30, 31, 30, 31, 
   
 ! find the day
 
-  current_dd = 0!since_dd
+  current_dd = 0 ! since_dd
 
   do while (count_sec <= sec_since)
     current_dd = current_dd + 1
@@ -97,7 +103,7 @@ integer, dimension(12), parameter :: days_in_mm = (/31, 28, 31, 30, 31, 30, 31, 
   
 ! find the hour
 
-  current_hh = -1!since_hh
+  current_hh = -1 ! since_hh
 
   do while (count_sec <= sec_since)
     current_hh = current_hh + 1
@@ -109,7 +115,7 @@ integer, dimension(12), parameter :: days_in_mm = (/31, 28, 31, 30, 31, 30, 31, 
   
 ! find the minute
 
-  current_nn = -1!since_nn
+  current_nn = -1 ! since_nn
 
   do while (count_sec <= sec_since)
     current_nn = current_nn + 1


### PR DESCRIPTION
To support CPC runs that start pre-1970, added support for putting reference_date in namelist (default is still 1970-01-01) and made the accumulation integers in time_utilities support integer*8 for long runs.

Restart tests passed and no answer changes.