### PR TITLE
change variable snow_levels to active_snow_levels

### DIFF
--- a/driver/ufsLandGenericIO.f90
+++ b/driver/ufsLandGenericIO.f90
@@ -93,9 +93,9 @@ contains
      (noahmp%model%max_vegetation_frac%output_flag  .and. io_type == output )) &
     call Define1dReal(noahmp%model%max_vegetation_frac, ncid, realtype, dim_id_loc, dim_id_time)
 
-  if((noahmp%model%snow_levels%restart_flag .and. io_type == restart) .or. &
-     (noahmp%model%snow_levels%output_flag  .and. io_type == output )) &
-    call Define1dReal(noahmp%model%snow_levels, ncid, realtype, dim_id_loc, dim_id_time)
+  if((noahmp%model%active_snow_levels%restart_flag .and. io_type == restart) .or. &
+     (noahmp%model%active_snow_levels%output_flag  .and. io_type == output )) &
+    call Define1dReal(noahmp%model%active_snow_levels, ncid, realtype, dim_id_loc, dim_id_time)
 
   if((noahmp%model%interface_depth%restart_flag .and. io_type == restart) .or. &
      (noahmp%model%interface_depth%output_flag  .and. io_type == output )) &
@@ -756,9 +756,9 @@ contains
     call Write1dReal(noahmp%model%max_vegetation_frac, ncid,   &
       start = (/local_start,output_counter/), count = (/namelist%subset_length, 1/))
 
-  if((noahmp%model%snow_levels%restart_flag .and. io_type == restart) .or. &
-     (noahmp%model%snow_levels%output_flag  .and. io_type == output )) &
-    call Write1dReal(noahmp%model%snow_levels, ncid,   &
+  if((noahmp%model%active_snow_levels%restart_flag .and. io_type == restart) .or. &
+     (noahmp%model%active_snow_levels%output_flag  .and. io_type == output )) &
+    call Write1dReal(noahmp%model%active_snow_levels, ncid,   &
       start = (/local_start,output_counter/), count = (/namelist%subset_length, 1/))
 
   if((noahmp%model%interface_depth%restart_flag .and. io_type == restart) .or. &
@@ -1560,8 +1560,8 @@ contains
     call Read1dReal(noahmp%model%max_vegetation_frac, ncid,   &
       start = (/local_start,1/), count = (/namelist%subset_length, 1/))
 
-  if(noahmp%model%snow_levels%restart_flag) &
-    call Read1dReal(noahmp%model%snow_levels, ncid,   &
+  if(noahmp%model%active_snow_levels%restart_flag) &
+    call Read1dReal(noahmp%model%active_snow_levels, ncid,   &
       start = (/local_start,1/), count = (/namelist%subset_length, 1/))
 
   if(noahmp%model%interface_depth%restart_flag) &

--- a/driver/ufsLandNoahMPDriverModule.f90
+++ b/driver/ufsLandNoahMPDriverModule.f90
@@ -192,7 +192,7 @@ associate (                                                      &
    snow_mp    => noahmp%forcing%precip_snow%data                ,&
    graupel_mp => noahmp%forcing%precip_graupel%data             ,&
    ice_mp     => noahmp%forcing%precip_hail%data                ,&
-   snowxy     => noahmp%model%snow_levels%data                  ,&
+   snowxy     => noahmp%model%active_snow_levels%data           ,&
    tvxy       => noahmp%state%temperature_leaf%data             ,&
    tgxy       => noahmp%state%temperature_ground%data           ,&
    canicexy   => noahmp%state%canopy_ice%data                   ,&

--- a/driver/ufsLandNoahMPType.f90
+++ b/driver/ufsLandNoahMPType.f90
@@ -58,7 +58,7 @@ type :: noahmp_model_type
   type(real1d)          :: forcing_height           ! forcing height [m]
   type(real1d)          :: vegetation_fraction      ! vegetation fraction [0.0-1.0]
   type(real1d)          :: max_vegetation_frac      ! annual maximum vegetation fraction [0.0-1.0]
-  type(real1d)          :: snow_levels              ! active snow levels [-]
+  type(real1d)          :: active_snow_levels       ! active snow levels [-]
   type(real2d)          :: interface_depth          ! layer-bottom depth from snow surf [m]
   type(real2d)          :: snow_soil_thickness      ! thickness of each snow/soil level [m]
   type(real1d)          :: leaf_area_index          ! leaf area index [-]
@@ -353,11 +353,11 @@ contains
                     "fraction"                                  , &
                     namelist%output_names, namelist%restart_names)
 
-    call InitReal1d(this%model%snow_levels , &
-                    vector_length          , &
-                    "snow_levels"          , &
-                    "active snow levels"   , &
-                    "-"                    , &
+    call InitReal1d(this%model%active_snow_levels , &
+                    vector_length                 , &
+                    "active_snow_levels"          , &
+                    "active snow levels"          , &
+                    "-"                           , &
                     namelist%output_names, namelist%restart_names)
 
     call InitReal2d(this%model%interface_depth                , &
@@ -1506,7 +1506,7 @@ contains
     this%diag%soil_moisture_total%restart_flag     = .true.
     this%flux%precip_adv_heat_total%restart_flag   = .true.
     this%model%cosine_zenith%restart_flag          = .true.
-    this%model%snow_levels%restart_flag            = .true.
+    this%model%active_snow_levels%restart_flag     = .true.
     this%state%temperature_leaf%restart_flag       = .true.
     this%state%temperature_ground%restart_flag     = .true.
     this%state%canopy_ice%restart_flag             = .true.
@@ -1676,26 +1676,26 @@ contains
 
     this%model%snow_soil_thickness%data = 0.0
     if (snow_depth_meters < 0.025 ) then
-      this%model%snow_levels%data(iloc)              = 0.0
+      this%model%active_snow_levels%data(iloc)       = 0.0
       this%model%snow_soil_thickness%data(iloc,-2:0) = 0.0
     elseif (snow_depth_meters >= 0.025 .and. snow_depth_meters <= 0.05 ) then
-      this%model%snow_levels%data(iloc)              = -1.0
+      this%model%active_snow_levels%data(iloc)       = -1.0
       this%model%snow_soil_thickness%data(iloc,0)    = snow_depth_meters
     elseif (snow_depth_meters > 0.05 .and. snow_depth_meters <= 0.10 ) then
-      this%model%snow_levels%data(iloc)              = -2.0
+      this%model%active_snow_levels%data(iloc)       = -2.0
       this%model%snow_soil_thickness%data(iloc,-1)   = 0.5*snow_depth_meters
       this%model%snow_soil_thickness%data(iloc,0)    = 0.5*snow_depth_meters
     elseif (snow_depth_meters > 0.10 .and. snow_depth_meters <= 0.25 ) then
-      this%model%snow_levels%data(iloc)                   = -2.0
+      this%model%active_snow_levels%data(iloc)       = -2.0
       this%model%snow_soil_thickness%data(iloc,-1)   = 0.05
       this%model%snow_soil_thickness%data(iloc,0)    = snow_depth_meters - 0.05
     elseif (snow_depth_meters > 0.25 .and. snow_depth_meters <= 0.45 ) then
-      this%model%snow_levels%data(iloc)                   = -3.0
+      this%model%active_snow_levels%data(iloc)       = -3.0
       this%model%snow_soil_thickness%data(iloc,-2)   = 0.05
       this%model%snow_soil_thickness%data(iloc,-1)   = 0.5*(snow_depth_meters-0.05)
       this%model%snow_soil_thickness%data(iloc,0)    = 0.5*(snow_depth_meters-0.05)
     elseif (snow_depth_meters > 0.45) then 
-      this%model%snow_levels%data(iloc)                   = -3.0
+      this%model%active_snow_levels%data(iloc)       = -3.0
       this%model%snow_soil_thickness%data(iloc,-2)   = 0.05
       this%model%snow_soil_thickness%data(iloc,-1)   = 0.20
       this%model%snow_soil_thickness%data(iloc,0)    = snow_depth_meters - 0.05 - 0.20
@@ -1711,7 +1711,7 @@ contains
     this%state%snow_level_liquid%data(iloc,-2:0) = 0.0
     this%model%interface_depth%data  (iloc,-2:namelist%num_soil_levels) = 0.0
 
-    isnow = nint(this%model%snow_levels%data(iloc)) + 1    ! snow_levels <=0.0, interface_depth >= 0.0
+    isnow = nint(this%model%active_snow_levels%data(iloc)) + 1    ! active_snow_levels <=0.0, interface_depth >= 0.0
 
     do ilevel = isnow , 0
       this%state%temperature_snow%data (iloc,ilevel) = this%state%temperature_ground%data(iloc)


### PR DESCRIPTION
snow_levels is used both for the variable active snow levels and the dimension of snow variables in output/restart files. This causes some problems with nco (e.g., ncrcat). Change variable snow_levels to active_snow_levels to avoid conflict with dimension name.